### PR TITLE
Fix "Spessman" font

### DIFF
--- a/_sass/general.scss
+++ b/_sass/general.scss
@@ -27,9 +27,11 @@ h6 {
     color: $color-header;
     font-size: 36px;
     font-family: "Spessman", sans-serif;
-    @font-face {
-        font-family: "Spessman";
-        src: url("../assets/misc/spessmanfont.tff");
+    @at-root {
+        @font-face {
+            font-family: "Spessman";
+            src: url("../assets/misc/spessmanfont.ttf");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Spessman font is not loading because of wrong rule and wrong path to the font. This PR fixes it.

## Pictures/Videos (optional)

Now font is properly displayed.
![image](https://user-images.githubusercontent.com/12456395/144305989-8a30a86c-23ed-4b83-a692-27f53dc409c1.png)

## Changes to Files

`_sass/general.scss` - add `@at-root` rule to Spessman's font-face and fix the path to the font 

## Known issues

## Fixes (optional)

Closes #33 